### PR TITLE
Pull the Docker image (instead of building it)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,9 +2,9 @@ name: Build artifacts
 
 on:
   workflow_call:
-    inputs:
+    secrets:
       GITHUB_TOKEN:
-        type: string
+        required: true
         description: GITHUB_TOKEN to access the repository
 
 env:
@@ -13,8 +13,8 @@ env:
 jobs:
   next_semantic_version:
     uses: ./.github/workflows/next-semantic-version.yaml
-    with:
-      GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
+    secrets:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   docker_image:
     needs:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,10 +2,6 @@ name: Build artifacts
 
 on:
   workflow_call:
-    secrets:
-      GITHUB_TOKEN:
-        required: true
-        description: GITHUB_TOKEN to access the repository
 
 env:
   REGISTRY: ghcr.io
@@ -13,8 +9,6 @@ env:
 jobs:
   next_semantic_version:
     uses: ./.github/workflows/next-semantic-version.yaml
-    secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   docker_image:
     needs:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,37 +7,15 @@ env:
   REGISTRY: ghcr.io
 
 jobs:
-  get_next_release_version:
-    permissions:
-      contents: write
-    outputs:
-      next_release_version: ${{ steps.semantic.outputs.NEXT_RELEASE_VERSION }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "lts/*"
-
-      - name: Get next version
-        id: semantic
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          export NEXT_RELEASE_VERSION=$(npx semantic-release --dry-run | grep 'next release version is' | sed -E 's/.* ([[:digit:].]+)$/\1/')
-          echo "NEXT_RELEASE_VERSION=${NEXT_RELEASE_VERSION}" >> $GITHUB_OUTPUT
+  next_semantic_version:
+    uses: ./.github/workflows/next-semantic-version.yaml
 
   docker_image:
     needs:
-      - get_next_release_version
+      - next_semantic_version
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       packages: write
     steps:
       - name: Checkout
@@ -70,4 +48,4 @@ jobs:
           context: .
           push: true
           tags: |
-            ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:v${{ needs.get_next_release_version.outputs.next_release_version }}
+            ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:v${{ needs.next_semantic_version.outputs.next_release_version }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,6 +2,10 @@ name: Build artifacts
 
 on:
   workflow_call:
+    inputs:
+      GITHUB_TOKEN:
+        type: string
+        description: GITHUB_TOKEN to access the repository
 
 env:
   REGISTRY: ghcr.io
@@ -9,6 +13,8 @@ env:
 jobs:
   next_semantic_version:
     uses: ./.github/workflows/next-semantic-version.yaml
+    with:
+      GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
 
   docker_image:
     needs:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -18,6 +18,8 @@ jobs:
     needs:
       - test
     uses: ./.github/workflows/build.yaml
+    with:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   release:
     needs:

--- a/.github/workflows/next-semantic-version.yaml
+++ b/.github/workflows/next-semantic-version.yaml
@@ -29,11 +29,11 @@ jobs:
       - name: Get branch name
         id: branch
         run : |
-          git rev-parse --abbrev-ref HEAD
+          echo "GITHUB_REF=$GITHUB_REF"
           if [[ ${{ inputs.is_branch_main }} == true ]]; then
             echo "BRANCH=main" >> "$GITHUB_OUTPUT"
           else
-            echo "BRANCH=$(git rev-parse --abbrev-ref HEAD)" >> "$GITHUB_OUTPUT"
+            echo "BRANCH=$GITHUB_REF" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Setup Node.js

--- a/.github/workflows/next-semantic-version.yaml
+++ b/.github/workflows/next-semantic-version.yaml
@@ -37,5 +37,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          npx semantic-release --dry-run --no-ci --branches "${{ inputs.branch }}"
           export NEXT_SEMANTIC_RELEASE_VERSION=$(npx semantic-release --dry-run --no-ci --branches "${{ inputs.branch }}" | grep 'next release version is' | sed -E 's/.* ([[:digit:].]+)$/\1/')
           echo "NEXT_SEMANTIC_RELEASE_VERSION=${NEXT_SEMANTIC_RELEASE_VERSION}" >> $GITHUB_OUTPUT

--- a/.github/workflows/next-semantic-version.yaml
+++ b/.github/workflows/next-semantic-version.yaml
@@ -2,6 +2,12 @@ name: Next Semantic Version
 
 on:
   workflow_call:
+    inputs:
+      branch:
+        description: The branch on which to run the semantic-version script
+        type: string
+        default: main
+
     outputs:
       next_release_version:
         description: The next semantic release version
@@ -15,11 +21,6 @@ jobs:
     outputs:
       next_semantic_version: ${{ steps.semantic.outputs.NEXT_SEMANTIC_RELEASE_VERSION }}
     steps:
-      - name: Extract branch name
-        id: branch
-        shell: bash
-        run: echo "BRANCH=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
-
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -36,6 +37,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          npx semantic-release --dry-run --no-ci --branches ${{ steps.branch.outputs.BRANCH }}
-          export NEXT_SEMANTIC_RELEASE_VERSION=$(npx semantic-release --dry-run --no-ci --branches ${{ steps.branch.outputs.BRANCH }} | grep 'next release version is' | sed -E 's/.* ([[:digit:].]+)$/\1/')
+          npx semantic-release --dry-run --no-ci --branches ${{ inputs.branch }}
+          export NEXT_SEMANTIC_RELEASE_VERSION=$(npx semantic-release --dry-run --no-ci --branches "${{ inputs.branch }}" | grep 'next release version is' | sed -E 's/.* ([[:digit:].]+)$/\1/')
           echo "NEXT_SEMANTIC_RELEASE_VERSION=${NEXT_SEMANTIC_RELEASE_VERSION}" >> $GITHUB_OUTPUT

--- a/.github/workflows/next-semantic-version.yaml
+++ b/.github/workflows/next-semantic-version.yaml
@@ -2,9 +2,9 @@ name: Next Semantic Version
 
 on:
   workflow_call:
-    inputs:
+    secrets:
       GITHUB_TOKEN:
-        type: string
+        required: true
         description: GITHUB_TOKEN to access the repository
 
     outputs:

--- a/.github/workflows/next-semantic-version.yaml
+++ b/.github/workflows/next-semantic-version.yaml
@@ -36,5 +36,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          npx semantic-release --dry-run --no-ci --branches ${{ steps.branch.outputs.BRANCH }}
           export NEXT_SEMANTIC_RELEASE_VERSION=$(npx semantic-release --dry-run --no-ci --branches ${{ steps.branch.outputs.BRANCH }} | grep 'next release version is' | sed -E 's/.* ([[:digit:].]+)$/\1/')
           echo "NEXT_SEMANTIC_RELEASE_VERSION=${NEXT_SEMANTIC_RELEASE_VERSION}" >> $GITHUB_OUTPUT

--- a/.github/workflows/next-semantic-version.yaml
+++ b/.github/workflows/next-semantic-version.yaml
@@ -37,6 +37,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          npx semantic-release --dry-run --no-ci --branches ${{ inputs.branch }}
           export NEXT_SEMANTIC_RELEASE_VERSION=$(npx semantic-release --dry-run --no-ci --branches "${{ inputs.branch }}" | grep 'next release version is' | sed -E 's/.* ([[:digit:].]+)$/\1/')
           echo "NEXT_SEMANTIC_RELEASE_VERSION=${NEXT_SEMANTIC_RELEASE_VERSION}" >> $GITHUB_OUTPUT

--- a/.github/workflows/next-semantic-version.yaml
+++ b/.github/workflows/next-semantic-version.yaml
@@ -6,7 +6,6 @@ on:
       GITHUB_TOKEN:
         type: string
         description: GITHUB_TOKEN to access the repository
-        default: ${{ secrets.GITHUB_TOKEN }}
 
     outputs:
       next_release_version:

--- a/.github/workflows/next-semantic-version.yaml
+++ b/.github/workflows/next-semantic-version.yaml
@@ -1,0 +1,41 @@
+name: Next Semantic Version
+
+on:
+  workflow_call:
+    inputs:
+      GITHUB_TOKEN:
+        type: string
+        description: GITHUB_TOKEN to access the repository
+        default: ${{ secrets.GITHUB_TOKEN }}
+
+    outputs:
+      next_release_version:
+        description: The next semantic release version
+        value: ${{ jobs.next_version.outputs.next_semantic_version }}
+
+jobs:
+  next_version:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      next_semantic_version: ${{ steps.semantic.outputs.NEXT_SEMANTIC_RELEASE_VERSION }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "lts/*"
+
+      - name: Get next semantic version
+        id: semantic
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
+        run: |
+          export NEXT_SEMANTIC_RELEASE_VERSION=$(npx semantic-release --dry-run | grep 'next release version is' | sed -E 's/.* ([[:digit:].]+)$/\1/')
+          echo "NEXT_SEMANTIC_RELEASE_VERSION=${NEXT_SEMANTIC_RELEASE_VERSION}" >> $GITHUB_OUTPUT

--- a/.github/workflows/next-semantic-version.yaml
+++ b/.github/workflows/next-semantic-version.yaml
@@ -2,11 +2,6 @@ name: Next Semantic Version
 
 on:
   workflow_call:
-    secrets:
-      GITHUB_TOKEN:
-        required: true
-        description: GITHUB_TOKEN to access the repository
-
     outputs:
       next_release_version:
         description: The next semantic release version
@@ -34,7 +29,7 @@ jobs:
         id: semantic
         shell: bash
         env:
-          GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           export NEXT_SEMANTIC_RELEASE_VERSION=$(npx semantic-release --dry-run | grep 'next release version is' | sed -E 's/.* ([[:digit:].]+)$/\1/')
           echo "NEXT_SEMANTIC_RELEASE_VERSION=${NEXT_SEMANTIC_RELEASE_VERSION}" >> $GITHUB_OUTPUT

--- a/.github/workflows/next-semantic-version.yaml
+++ b/.github/workflows/next-semantic-version.yaml
@@ -2,12 +2,6 @@ name: Next Semantic Version
 
 on:
   workflow_call:
-    inputs:
-      is_branch_main:
-        description: Is the branch "main" to run the semantic-version script
-        type: boolean
-        default: true
-
     outputs:
       next_release_version:
         description: The next semantic release version
@@ -25,16 +19,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
-      - name: Get branch name
-        id: branch
-        run : |
-          echo "GITHUB_REF=$GITHUB_REF"
-          if [[ ${{ inputs.is_branch_main }} == true ]]; then
-            echo "BRANCH=main" >> "$GITHUB_OUTPUT"
-          else
-            echo "BRANCH=$GITHUB_REF" >> "$GITHUB_OUTPUT"
-          fi
+          ref: ${{ github.head_ref }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -47,6 +32,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          npx semantic-release --dry-run --no-ci --branches "${{ steps.branch.outputs.BRANCH }}"
-          export NEXT_SEMANTIC_RELEASE_VERSION=$(npx semantic-release --dry-run --no-ci --branches "${{ steps.branch.outputs.BRANCH }}" | grep 'next release version is' | sed -E 's/.* ([[:digit:].]+)$/\1/')
+          npx semantic-release --dry-run --no-ci --branches "${{ github.head_ref }}"
+          export NEXT_SEMANTIC_RELEASE_VERSION=$(npx semantic-release --dry-run --no-ci --branches "${{ github.head_ref }}" | grep 'next release version is' | sed -E 's/.* ([[:digit:].]+)$/\1/')
           echo "NEXT_SEMANTIC_RELEASE_VERSION=${NEXT_SEMANTIC_RELEASE_VERSION}" >> $GITHUB_OUTPUT

--- a/.github/workflows/next-semantic-version.yaml
+++ b/.github/workflows/next-semantic-version.yaml
@@ -32,6 +32,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          npx semantic-release --dry-run --no-ci --branches "${{ github.head_ref }}"
-          export NEXT_SEMANTIC_RELEASE_VERSION=$(npx semantic-release --dry-run --no-ci --branches "${{ github.head_ref }}" | grep 'next release version is' | sed -E 's/.* ([[:digit:].]+)$/\1/')
+          unset GITHUB_ACTIONS && npx semantic-release --dry-run --no-ci --branches "${{ github.head_ref }}"
+          export NEXT_SEMANTIC_RELEASE_VERSION=$(unset GITHUB_ACTIONS && npx semantic-release --dry-run --no-ci --branches "${{ github.head_ref }}" | grep 'next release version is' | sed -E 's/.* ([[:digit:].]+)$/\1/')
           echo "NEXT_SEMANTIC_RELEASE_VERSION=${NEXT_SEMANTIC_RELEASE_VERSION}" >> $GITHUB_OUTPUT

--- a/.github/workflows/next-semantic-version.yaml
+++ b/.github/workflows/next-semantic-version.yaml
@@ -15,6 +15,11 @@ jobs:
     outputs:
       next_semantic_version: ${{ steps.semantic.outputs.NEXT_SEMANTIC_RELEASE_VERSION }}
     steps:
+      - name: Extract branch name
+        id: branch
+        shell: bash
+        run: echo "BRANCH=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -31,5 +36,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          export NEXT_SEMANTIC_RELEASE_VERSION=$(npx semantic-release --dry-run | grep 'next release version is' | sed -E 's/.* ([[:digit:].]+)$/\1/')
+          export NEXT_SEMANTIC_RELEASE_VERSION=$(npx semantic-release --dry-run --no-ci --branches ${{ steps.branch.outputs.BRANCH }} | grep 'next release version is' | sed -E 's/.* ([[:digit:].]+)$/\1/')
           echo "NEXT_SEMANTIC_RELEASE_VERSION=${NEXT_SEMANTIC_RELEASE_VERSION}" >> $GITHUB_OUTPUT

--- a/.github/workflows/next-semantic-version.yaml
+++ b/.github/workflows/next-semantic-version.yaml
@@ -32,6 +32,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          unset GITHUB_ACTIONS && npx semantic-release --dry-run --no-ci --branches "${{ github.head_ref }}"
-          export NEXT_SEMANTIC_RELEASE_VERSION=$(unset GITHUB_ACTIONS && npx semantic-release --dry-run --no-ci --branches "${{ github.head_ref }}" | grep 'next release version is' | sed -E 's/.* ([[:digit:].]+)$/\1/')
-          echo "NEXT_SEMANTIC_RELEASE_VERSION=${NEXT_SEMANTIC_RELEASE_VERSION}" >> $GITHUB_OUTPUT
+          echo "NEXT_SEMANTIC_RELEASE_VERSION=$(unset GITHUB_ACTIONS && npx semantic-release --dry-run --no-ci --branches "${{ github.head_ref }}" | grep 'next release version is' | sed -E 's/.* ([[:digit:].]+)$/\1/')" >> $GITHUB_OUTPUT

--- a/.github/workflows/next-semantic-version.yaml
+++ b/.github/workflows/next-semantic-version.yaml
@@ -3,10 +3,10 @@ name: Next Semantic Version
 on:
   workflow_call:
     inputs:
-      branch:
-        description: The branch on which to run the semantic-version script
-        type: string
-        default: main
+      is_branch_main:
+        description: Is the branch "main" to run the semantic-version script
+        type: boolean
+        default: true
 
     outputs:
       next_release_version:
@@ -26,6 +26,16 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Get branch name
+        id: branch
+        run : |
+          git rev-parse --abbrev-ref HEAD
+          if [[ ${{ inputs.is_branch_main }} == true ]]; then
+            echo "BRANCH=main" >> "$GITHUB_OUTPUT"
+          else
+            echo "BRANCH=$(git rev-parse --abbrev-ref HEAD)" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -37,6 +47,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          npx semantic-release --dry-run --no-ci --branches "${{ inputs.branch }}"
-          export NEXT_SEMANTIC_RELEASE_VERSION=$(npx semantic-release --dry-run --no-ci --branches "${{ inputs.branch }}" | grep 'next release version is' | sed -E 's/.* ([[:digit:].]+)$/\1/')
+          npx semantic-release --dry-run --no-ci --branches "${{ steps.branch.outputs.BRANCH }}"
+          export NEXT_SEMANTIC_RELEASE_VERSION=$(npx semantic-release --dry-run --no-ci --branches "${{ steps.branch.outputs.BRANCH }}" | grep 'next release version is' | sed -E 's/.* ([[:digit:].]+)$/\1/')
           echo "NEXT_SEMANTIC_RELEASE_VERSION=${NEXT_SEMANTIC_RELEASE_VERSION}" >> $GITHUB_OUTPUT

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -11,8 +11,6 @@ jobs:
 
   next_semantic_version:
     uses: ./.github/workflows/next-semantic-version.yaml
-    secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   check_docker_image:
     needs:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -14,8 +14,6 @@ jobs:
 
   next_semantic_version:
     uses: ./.github/workflows/next-semantic-version.yaml
-    with:
-      is_branch_main: false
 
   check_docker_image:
     needs:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Get current docker image version
         id: current_version
-        run: echo "DOCKER_IMAGE_VERSION=$(s/docker:\/\/ghcr.io\/landazuripaul\/time-window-validator:v[0-9]*.[0-9]*.[0-9]*/\1/g')" >> "$GITHUB_OUTPUT"
+        run: echo "DOCKER_IMAGE_VERSION=$(s/docker:\/\/ghcr.io\/landazuripaul\/time-window-validator:v[0-9]*.[0-9]*.[0-9]*/\1/g)" >> "$GITHUB_OUTPUT"
 
       - name: Compare docker image with next version
         uses: actions/github-script@v7

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -4,12 +4,15 @@ on:
   pull_request:
     branches:
       - main
+
 jobs:
   test:
     uses: ./.github/workflows/test.yaml
 
   next_semantic_version:
     uses: ./.github/workflows/next-semantic-version.yaml
+    with:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   check_docker_image:
     needs:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -11,7 +11,7 @@ jobs:
 
   next_semantic_version:
     uses: ./.github/workflows/next-semantic-version.yaml
-    with:
+    secrets:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   check_docker_image:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -7,3 +7,27 @@ on:
 jobs:
   test:
     uses: ./.github/workflows/test.yaml
+
+  next_semantic_version:
+    uses: ./.github/workflows/next-semantic-version.yaml
+
+  check_docker_image:
+    needs:
+      - next_semantic_version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Get current docker image version
+        id: current_version
+        run: echo "DOCKER_IMAGE_VERSION=$(s/docker:\/\/ghcr.io\/landazuripaul\/time-window-validator:v[0-9]*.[0-9]*.[0-9]*/\1/g')" >> "$GITHUB_OUTPUT"
+
+      - name: Compare docker image with next version
+        uses: actions/github-script@v7
+        with:
+          script: |
+            if ("${{ needs.next_semantic_version.outputs.next_release_version }}" !== "${{ steps.current_version.outputs.DOCKER_IMAGE_VERSION }}") {
+              core.setFailed("The action.yaml's Docker image is pointing at ${{ steps.current_version.outputs.DOCKER_IMAGE_VERSION }} but it should point at the next semantic version ${{ needs.next_semantic_version.outputs.next_release_version }}")
+            }
+

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+
 jobs:
   test:
     uses: ./.github/workflows/test.yaml

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -15,7 +15,7 @@ jobs:
   next_semantic_version:
     uses: ./.github/workflows/next-semantic-version.yaml
     with:
-     branch: "**"
+      is_branch_main: false
 
   check_docker_image:
     needs:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -14,6 +14,8 @@ jobs:
 
   next_semantic_version:
     uses: ./.github/workflows/next-semantic-version.yaml
+    with:
+     branch: "**"
 
   check_docker_image:
     needs:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -25,7 +25,8 @@ jobs:
 
       - name: Get current docker image version
         id: current_version
-        run: echo "DOCKER_IMAGE_VERSION=$(s/docker:\/\/ghcr.io\/landazuripaul\/time-window-validator:v[0-9]*.[0-9]*.[0-9]*/\1/g)" >> "$GITHUB_OUTPUT"
+        run: |
+          echo "DOCKER_IMAGE_VERSION=$(cat action.yaml | grep "docker://ghcr.io" | sed -E 's/.*:v([0-9]*.[0-9]*.[0-9]*)$/\1/')" >> "$GITHUB_OUTPUT"
 
       - name: Compare docker image with next version
         uses: actions/github-script@v7

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,6 +29,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Force local Dockerfile for testing
+        run: |
+          sed -i 's/docker:\/\/ghcr.io\/landazuripaul\/time-window-validator:v[0-9]*.[0-9]*.[0-9]*/Dockerfile/g' action.yaml
+
       - name: Test  Docker action
         id: time_window
         uses: ./

--- a/.releaserc
+++ b/.releaserc
@@ -1,7 +1,4 @@
 {
-  "branches": [
-    "main"
-  ],
   "tagFormat": "v${version}",
   "plugins": [
     "@semantic-release/commit-analyzer",

--- a/.releaserc
+++ b/.releaserc
@@ -1,4 +1,7 @@
 {
+  "branches": [
+    "main"
+  ],
   "tagFormat": "v${version}",
   "plugins": [
     "@semantic-release/commit-analyzer",

--- a/action.yaml
+++ b/action.yaml
@@ -36,7 +36,7 @@ inputs:
     default: '0'
 runs:
   using: docker
-  image: Dockerfile
+  image: docker://ghcr.io/landazuripaul/time-window-validator:v1.0.0
   args:
     - -allowed
     - ${{ inputs.allowed }}

--- a/action.yaml
+++ b/action.yaml
@@ -36,7 +36,7 @@ inputs:
     default: '0'
 runs:
   using: docker
-  image: docker://ghcr.io/landazuripaul/time-window-validator:v1.0.0
+  image: docker://ghcr.io/landazuripaul/time-window-validator:v1.1.0
   args:
     - -allowed
     - ${{ inputs.allowed }}


### PR DESCRIPTION
This PR speeds up the action since it removes the need to build the Docker image on every run. Instead, it just pulls the Docker image.

To make sure the overall action's release number and the Docker image version don't drift apart, there is a new workflow to check any PR updates the image version as expected.